### PR TITLE
Support error values in ext ops

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -273,11 +273,11 @@ export function createConversation<C extends Context>(
                 const current = conversations[i];
                 try {
                     op = await runOnLog(current.log);
-                } finally {
-                    if (op === "done") {
-                        conversations.splice(i, 1);
-                    }
+                } catch (e) {
+                    conversations.splice(i, 1);
+                    throw e;
                 }
+                if (op === "done") conversations.splice(i, 1);
             }
             return op;
         }


### PR DESCRIPTION
We now store an `ok` flag alongside external ops which are performed. That way, we can repeat throwing errors upon failing ext ops.

Also, we finally support `conversation.external(() => 0)` rather than `conversation.external({ task: () => 0 })`.

Closes #7.