### PR TITLE
fix: update form.text types to mach JSDoc and the other functions

### DIFF
--- a/src/form.ts
+++ b/src/form.ts
@@ -112,7 +112,7 @@ export class ConversationForm<C extends Context> {
      */
     async select<T extends string>(
         options: T[],
-        otherwise: (ctx: C) => Promise<unknown> | unknown,
+        otherwise?: (ctx: C) => Promise<unknown> | unknown,
     ) {
         const opts: string[] = options;
         const ctx = await this.conversation.wait();


### PR DESCRIPTION
The JSDoc says that you **may** specify the `otherwise` function, and the code does handle it being undefined, but currently the types make it required. This updates the function type so you can omit `otherwise`.