### PR TITLE
fix: do not crash when functions are missing from ctx but throw a warning

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -565,8 +565,18 @@ export class ConversationHandle<C extends Context> {
             x,
         ) as C;
         // Copy over functions which we could not store
-        // deno-lint-ignore no-explicit-any
-        f.forEach((p) => (ctx as any)[p] = (this.ctx as any)[p].bind(this.ctx));
+        f.forEach((key) => {
+            // deno-lint-ignore no-explicit-any
+            const current = (this.ctx as any)[key];
+            if (typeof current !== "function") {
+                console.error(
+                    `WARNING: grammY conversations: Previously installed function '${key}' is now missing on context object! Is the middleware order incorrect?`,
+                );
+                return;
+            }
+            // deno-lint-ignore no-explicit-any
+            (ctx as any)[key] = current.bind(this.ctx);
+        });
         this.currentCtx = ctx;
         return ctx;
     }

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -788,14 +788,14 @@ describe("The conversation engine", () => {
     });
     describe("provides conversation.log", () => {
         it("which should print logs", async () => {
-            const log = spy(console, "log");
+            const log = stub(console, "log");
             await testConversation((conversation) => conversation.log("debug"));
             assertEquals(log.calls.length, 1);
             assertEquals(log.calls[0].args, ["debug"]);
             log.restore();
         });
         it("which should not print logs during replaying", async () => {
-            const log = spy(console, "log");
+            const log = stub(console, "log");
             await testConversation(
                 async (conversation) => {
                     conversation.log("debug");


### PR DESCRIPTION
Closes #54.