### PR TITLE
feat: transform data using oson

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     },
     "dependencies": {
         "@grammyjs/types": "^2.8.2",
-        "debug": "^4.3.4"
+        "debug": "^4.3.4",
+        "o-son": "^1.0.0"
     },
     "peerDependencies": {
         "grammy": "^1.10.0"

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -1,4 +1,3 @@
-import { GLOBAL_CONSTRUCTOR_MAP } from "https://deno.land/x/oson@1.0.0/constructors.ts";
 import {
     type ApiResponse,
     type CallbackQueryContext,
@@ -9,6 +8,7 @@ import {
     type Filter,
     type FilterQuery,
     type GameQueryContext,
+    GLOBAL_CONSTRUCTOR_MAP,
     GrammyError,
     type HearsContext,
     HttpError,

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,3 +1,7 @@
-export { delistify, listify } from "https://deno.land/x/oson@1.0.0/mod.ts";
+export {
+    delistify,
+    GLOBAL_CONSTRUCTOR_MAP,
+    listify,
+} from "https://deno.land/x/oson@1.0.0/mod.ts";
 export * from "https://lib.deno.dev/x/grammy@v1/mod.ts";
 export * from "https://lib.deno.dev/x/grammy@v1/types.ts";

--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -1,2 +1,3 @@
+export { delistify, listify } from "https://deno.land/x/oson@1.0.0/mod.ts";
 export * from "https://lib.deno.dev/x/grammy@v1/mod.ts";
 export * from "https://lib.deno.dev/x/grammy@v1/types.ts";

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -1,2 +1,3 @@
+export { delistify, listify } from "o-son";
 export * from "grammy";
 export * from "@grammyjs/types";

--- a/src/deps.node.ts
+++ b/src/deps.node.ts
@@ -1,3 +1,3 @@
-export { delistify, listify } from "o-son";
+export { delistify, GLOBAL_CONSTRUCTOR_MAP, listify } from "o-son";
 export * from "grammy";
 export * from "@grammyjs/types";


### PR DESCRIPTION
Compresses the data the conversation plugin stores in the session by converting it using [oson](https://github.com/KnorpelSenf/oson). This

- reduces the size
- adds support for countless data types

Closes #28.