### PR TITLE
Do not add maxMilliseconds if 0 or undefined

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -960,7 +960,9 @@ export class ConversationHandle<C extends Context> {
         opts?: OtherwiseConfig<C>,
     ): Promise<C> {
         const { otherwise, drop, maxMilliseconds } = toObj(opts);
-        const ctx = maxMilliseconds ? await this.wait({ maxMilliseconds }) : await this.wait();
+        const ctx = maxMilliseconds
+            ? await this.wait({ maxMilliseconds })
+            : await this.wait();
         if (!await predicate(ctx)) {
             await otherwise?.(ctx);
             await this.skip({ drop });

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -960,7 +960,7 @@ export class ConversationHandle<C extends Context> {
         opts?: OtherwiseConfig<C>,
     ): Promise<C> {
         const { otherwise, drop, maxMilliseconds } = toObj(opts);
-        const ctx = await this.wait({ maxMilliseconds });
+        const ctx = maxMilliseconds ? await this.wait({ maxMilliseconds }) : await this.wait();
         if (!await predicate(ctx)) {
             await otherwise?.(ctx);
             await this.skip({ drop });


### PR DESCRIPTION
This also has the effect of not giving maxMilliseconds if it is 0 (falsy). A timeout of 0ms makes no sense anyway.