### PR TITLE
Update deps.deno.ts

### DIFF
--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -14,7 +14,7 @@ export {
     type Middleware,
     type MiddlewareFn,
     type ReactionContext,
-} from "https://lib.deno.dev/x/grammy@v1/mod.ts";
+} from "https://lib.deno.dev/x/grammy@v1.x/mod.ts";
 export type {
     Animation,
     ApiError,
@@ -45,4 +45,4 @@ export type {
     Video,
     VideoNote,
     Voice,
-} from "https://lib.deno.dev/x/grammy@v1/types.ts";
+} from "https://lib.deno.dev/x/grammy@v1.x/types.ts";


### PR DESCRIPTION
Before this PR, tsc will throw type error

<img width="1362" alt="image" src="https://github.com/user-attachments/assets/2bc79b7f-3751-4a1f-bfde-8b31580f1866" />

After this PR, all types can work correctly.

<img width="1337" alt="image" src="https://github.com/user-attachments/assets/1c21b990-431a-4da8-af26-72c00be4fa96" />

I believe docs on website should also be updated.