### PR TITLE
fix: extend post-completion protection to skip/halt/rewind

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -316,6 +316,11 @@ async function replayState(
         return res;
     }
     async function cancel(key?: unknown) {
+        if (complete) {
+            throw new Error(
+                "Cannot perform a cancel operation after the conversation has completed, are you missing an `await`?",
+            );
+        }
         canceled = true;
         interrupted = true;
         message = key;

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -4,6 +4,7 @@ import {
     assert,
     assertEquals,
     assertGreater,
+    assertRejects,
     assertSpyCall,
     assertSpyCalls,
     describe,
@@ -386,5 +387,34 @@ describe("ReplayEngine", () => {
         assertEquals(result.message, "y");
         assertSpyCalls(builder, 2);
         assertEquals(i, 0);
+    });
+    it("should throw error if the controls are used after the replay has finished", async () => {
+        let controls: ReplayControls | undefined;
+        const engine = new ReplayEngine((c) => {
+            controls = c;
+        });
+        const res = await engine.play();
+        assertEquals(res.type, "returned");
+        assertRejects(
+            async () => {
+                await controls?.action(() => 0, "");
+            },
+            Error,
+            "missing an `await`",
+        );
+        assertRejects(
+            async () => {
+                await controls?.cancel();
+            },
+            Error,
+            "missing an `await`",
+        );
+        assertRejects(
+            async () => {
+                await controls?.interrupt("");
+            },
+            Error,
+            "missing an `await`",
+        );
     });
 });


### PR DESCRIPTION
We already prevent API calls after the replay has finished because it would lead to a no-op. This was forgotten for calls to `conversation.{halt,skip,rewind}`.

This PQ fixes that.