### PR TITLE
feat: expose conversation handle to plugins

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -103,7 +103,11 @@ export interface ConversationOptions<OC extends Context, C extends Context> {
      * each conversation will have the plugins installed that you specify
      * explicitly when using {@link enterConversation}.
      */
-    plugins?: Middleware<C>[];
+    plugins?:
+        | Middleware<C>[]
+        | ((
+            conversation: Conversation<OC, C>,
+        ) => Middleware<C>[] | Promise<Middleware<C>[]>);
     /**
      * Called when a conversation is entered via `ctx.conversation.enter`.
      *

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -93,6 +93,43 @@ describe("Conversation", () => {
         assert(fifth.status === "complete");
         assertEquals(i, 2);
     });
+    it("should wait with Promise.all", async () => {
+        const ctx = mkctx();
+        let i = 0;
+        async function convo(conversation: Convo) {
+            await Promise.all([
+                conversation.wait(),
+                conversation.wait(),
+                conversation.wait(),
+                conversation.wait(),
+            ]);
+            i++;
+        }
+        const first = await enterConversation(convo, ctx);
+        assertEquals(first.status, "handled");
+        assert(first.status === "handled");
+        assertEquals(i, 0);
+        const copy = structuredClone(first);
+        const second = await resumeConversation(convo, ctx, copy);
+        assertEquals(second.status, "handled");
+        assert(second.status === "handled");
+        assertEquals(i, 0);
+        const otherCopy = { ...structuredClone(second), args: first.args };
+        const third = await resumeConversation(convo, ctx, otherCopy);
+        assertEquals(third.status, "handled");
+        assert(third.status === "handled");
+        assertEquals(i, 0);
+        const thirdCopy = { ...structuredClone(third), args: first.args };
+        const fourth = await resumeConversation(convo, ctx, thirdCopy);
+        assertEquals(fourth.status, "handled");
+        assert(fourth.status === "handled");
+        assertEquals(i, 0);
+        const fourthCopy = { ...structuredClone(fourth), args: first.args };
+        const fifth = await resumeConversation(convo, ctx, fourthCopy);
+        assertEquals(fifth.status, "complete");
+        assert(fifth.status === "complete");
+        assertEquals(i, 1);
+    });
     it("should skip", async () => {
         let i = 0;
         let j = 0;

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -270,7 +270,7 @@ describe("createConversation", () => {
         assertEquals(i, 1);
         assertEquals(seq, "kiaeghfbcjlaeghfbcaeghfbdm");
     });
-    it.only("should support plugins that have access to the conversation handle", async () => {
+    it("should support plugins that have access to the conversation handle", async () => {
         const mw = new Composer<TestContext>();
         let i = 0;
         let seq = "";

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -859,6 +859,7 @@ describe("createConversation", () => {
 
             let i = 0;
             let p: Promise<unknown> | undefined;
+            const e = Promise.withResolvers<void>();
             mw.use(
                 conversations({
                     storage: {
@@ -868,14 +869,17 @@ describe("createConversation", () => {
                 }),
                 createConversation(async (c) => {
                     i++;
+                    e.resolve();
                     await c.wait();
                 }, "convo"),
                 (ctx) => {
+                    console.log("mw");
                     p = assertRejects(() => ctx.conversation.enter("convo"))
                         .then(() => i++);
                 },
             );
             await mw.middleware()(ctx, next);
+            await e.promise;
             assertEquals(i, 1);
             await p;
             assertEquals(i, 2);

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -219,6 +219,7 @@ describe("createConversation", () => {
     it("should support plugins", async () => {
         const mw = new Composer<TestContext>();
         let i = 0;
+        let seq = "";
 
         type PluginContext = TestContext & {
             phi: number;
@@ -227,31 +228,112 @@ describe("createConversation", () => {
         mw.use(
             conversations({
                 plugins: [async (ctx, next) => {
+                    seq += "a";
                     Object.assign(ctx, { phi: 0.5 * (1 + Math.sqrt(5)) });
                     await next();
+                    seq += "b";
                 }],
             }),
             createConversation(async (convo, ctx: PluginContext) => {
+                seq += "c";
                 assertEquals(ctx.prop, 42);
                 ctx = await convo.wait();
+                seq += "d";
                 assertEquals(ctx.prop, 42);
                 assertEquals(Math.round(ctx.phi), 2);
                 i++;
             }, {
                 id: "convo",
                 plugins: [async (ctx, next) => {
+                    seq += "e";
                     Object.assign(ctx, { prop: 0 });
                     await next();
+                    seq += "f";
                 }, async (ctx, next) => {
+                    seq += "g";
                     Object.assign(ctx, { prop: 42 });
                     await next();
+                    seq += "h";
                 }],
             }),
-            (ctx) => ctx.conversation.enter("convo"),
+            async (ctx) => {
+                seq += "i";
+                await ctx.conversation.enter("convo");
+                seq += "j";
+            },
         );
+        seq += "k";
         await mw.middleware()(mkctx(), next);
+        seq += "l";
         await mw.middleware()(mkctx(), next);
+        seq += "m";
         assertEquals(i, 1);
+        assertEquals(seq, "kiaeghfbcjlaeghfbcaeghfbdm");
+    });
+    it.only("should support plugins that have access to the conversation handle", async () => {
+        const mw = new Composer<TestContext>();
+        let i = 0;
+        let seq = "";
+        let kill = false;
+
+        type PluginContext = TestContext & {
+            phi: number;
+            prop: number;
+        };
+        mw.use(
+            conversations({
+                plugins: async (conversation) => {
+                    seq += "0";
+                    if (kill) await conversation.halt();
+                    return [async (ctx, next) => {
+                        seq += "a";
+                        Object.assign(ctx, { phi: 0.5 * (1 + Math.sqrt(5)) });
+                        await next();
+                        seq += "b";
+                    }];
+                },
+            }),
+            createConversation(async (convo, ctx: PluginContext) => {
+                seq += "c";
+                assertEquals(ctx.prop, 42);
+                ctx = await convo.wait();
+                seq += "d";
+                assertEquals(ctx.prop, 42);
+                assertEquals(Math.round(ctx.phi), 2);
+                i++;
+            }, {
+                id: "convo",
+                plugins: () => {
+                    seq += "1";
+                    return [async (ctx, next) => {
+                        seq += "e";
+                        Object.assign(ctx, { prop: 0 });
+                        await next();
+                        seq += "f";
+                    }, async (ctx, next) => {
+                        seq += "g";
+                        Object.assign(ctx, { prop: 42 });
+                        await next();
+                        seq += "h";
+                    }];
+                },
+            }),
+            async (ctx) => {
+                seq += "i";
+                await ctx.conversation.enter("convo");
+                seq += "j";
+            },
+        );
+        seq += "k";
+        await mw.middleware()(mkctx(), next);
+        seq += "l";
+        await mw.middleware()(mkctx(), next);
+        seq += "m";
+        kill = true;
+        await mw.middleware()(mkctx(), next);
+        seq += "n";
+        assertEquals(i, 1);
+        assertEquals(seq, "ki01aeghfbcjl01aeghfbc01aeghfbdmi0jn");
     });
     it("should halt the conversation upon default wait timeout", async () => {
         const onExit = spy(() => {});


### PR DESCRIPTION
The `plugins` option allows plugins to be installed inside a conversation, and `external` allows the conversation to read the session data. It was pointed out in https://t.me/grammyjs/291998 that it is currently impossible to access the session data from inside a plugin.

This PQ introduces a plugins option that has access to the conversation handle. That way, the following code becomes possible.
```ts
bot.use(createConversation(convo, {
  plugins: conversation => [async (ctx, next) => {
    // can now install session data on the context:
    ctx.sess = await conversation.external(ctx => ctx.session)
  }]
}))
```
