### PR TITLE
fix: make logs immutable

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -893,13 +893,6 @@ First return your data from `external` and then resume update handling using `wa
         const action = async () => {
             this.insideExternal = true;
             try {
-                // We perform an unsafe cast to the context type used in the
-                // surrounding middleware system. Technically, we could drag
-                // this type along from outside by adding an extra type
-                // parameter everywhere, but this makes all types too cumbersome
-                // to work with for bot developers. The benefits of this
-                // massively reduced complexity outweight the potential benefits
-                // of slightly stricter types for `external`.
                 const ret = await this.escape((ctx) => task(ctx));
                 return { ok: true, ret: await beforeStore(ret) } as const;
             } catch (e) {

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -903,10 +903,12 @@ First return your data from `external` and then resume update handling using `wa
         };
         // Recover values after loading them
         const ret = await this.controls.action(action, "external");
-        if (ret.ok) {
-            return await afterLoad(ret.ret);
+        // Clone them to provide immutability
+        const cloned = structuredClone(ret);
+        if (cloned.ok) {
+            return await afterLoad(cloned.ret);
         } else {
-            throw await afterLoadError(ret.err);
+            throw await afterLoadError(cloned.err);
         }
     }
     /**

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -160,7 +160,7 @@ describe("Conversation", () => {
         assert(second.status === "complete");
         assertEquals(i, 1);
     });
-    it.only("should return immutable data from external", async () => {
+    it("should return immutable data from external", async () => {
         const ctx = mkctx();
         const observe = spy((_counter: number) => {});
         async function convo(conversation: Convo) {

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -160,6 +160,29 @@ describe("Conversation", () => {
         assert(second.status === "complete");
         assertEquals(i, 1);
     });
+    it.only("should return immutable data from external", async () => {
+        const ctx = mkctx();
+        const observe = spy((_counter: number) => {});
+        async function convo(conversation: Convo) {
+            const pointer = await conversation.external(() => ({ counter: 0 }));
+            pointer.counter++;
+            const checkoint = conversation.checkpoint();
+            observe(pointer.counter);
+            await conversation.wait();
+            pointer.counter++;
+            await conversation.rewind(checkoint);
+        }
+        const first = await enterConversation(convo, ctx);
+        assertEquals(first.status, "handled");
+        assert(first.status === "handled");
+        const second = await resumeConversation(convo, ctx, first);
+        assertEquals(second.status, "handled");
+        assert(second.status === "handled");
+        assertSpyCalls(observe, 3);
+        assertSpyCall(observe, 0, { args: [1] });
+        assertSpyCall(observe, 1, { args: [1] });
+        assertSpyCall(observe, 2, { args: [1] });
+    });
     it("should support outside context objects in external", async () => {
         const ctx = mkctx({ update_id: Math.random() });
         let i = 0;


### PR DESCRIPTION
Currently, it is possible to mutate existing objects in the logs by returning their references from `external`, mutating them, and then using checkpoints to rewind the logs and access the mutated objects at a later point.

These changes fix that by returning a deep clone of all objects in the logs that are accessed via `external`. Note that (persistent) storage adapters have just deserialised the data before giving it back to the plugin at this point. In most cases, this means that it was parsed from JSON. It is therefore safe to clone it.

Regular wait calls and API calls are intentionally left unfixed. This is because it is extremely rare for people to mutate the update objects returned from wait calls or API calls. At the same time, those are a large part of the data in the logs. I feat that it would come at a significant runtime cost to always clone the entire log while it is being replayed.

Fixes #137.