### PR TITLE
fix: permit concurrent util calls

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -938,28 +938,28 @@ First return your data from `external` and then resume update handling using `wa
      * every replay. Prefer this over calling `Date.now()` directly.
      */
     async now() {
-        return await this.external(() => Date.now());
+        return await this.controls.action(() => Date.now(), "now");
     }
     /**
      * Takes `Math.random()` once when reached, and returns the same value
      * during every replay. Prefer this over calling `Math.random()` directly.
      */
     async random() {
-        return await this.external(() => Math.random());
+        return await this.controls.action(() => Math.random(), "random");
     }
     /**
      * Calls `console.log` only the first time it is reached, but not during
      * subsequent replays. Prefer this over calling `console.log` directly.
      */
     async log(...data: unknown[]) {
-        await this.external(() => console.log(...data));
+        await this.controls.action(() => console.log(...data), "log");
     }
     /**
      * Calls `console.error` only the first time it is reached, but not during
      * subsequent replays. Prefer this over calling `console.error` directly.
      */
     async error(...data: unknown[]) {
-        await this.external(() => console.error(...data));
+        await this.controls.action(() => console.error(...data), "error");
     }
 
     /**

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -938,7 +938,7 @@ First return your data from `external` and then resume update handling using `wa
      * every replay. Prefer this over calling `Date.now()` directly.
      */
     async now() {
-        const now = await this.controls.action(() => Date.now(), "now");
+        const now = await this.controls.action(() => Date.now(), "external");
         if (typeof now === "number") return now;
         // backwards compatibility with previous implementation via `external`
         return (now as { ret: number }).ret;
@@ -948,7 +948,10 @@ First return your data from `external` and then resume update handling using `wa
      * during every replay. Prefer this over calling `Math.random()` directly.
      */
     async random() {
-        const rand = await this.controls.action(() => Math.random(), "random");
+        const rand = await this.controls.action(
+            () => Math.random(),
+            "external",
+        );
         if (typeof rand === "number") return rand;
         // backwards compatibility with previous implementation via `external`
         return (rand as { ret: number }).ret;
@@ -958,14 +961,14 @@ First return your data from `external` and then resume update handling using `wa
      * subsequent replays. Prefer this over calling `console.log` directly.
      */
     async log(...data: unknown[]) {
-        await this.controls.action(() => console.log(...data), "log");
+        await this.controls.action(() => console.log(...data), "external");
     }
     /**
      * Calls `console.error` only the first time it is reached, but not during
      * subsequent replays. Prefer this over calling `console.error` directly.
      */
     async error(...data: unknown[]) {
-        await this.controls.action(() => console.error(...data), "error");
+        await this.controls.action(() => console.error(...data), "external");
     }
 
     /**

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -938,14 +938,20 @@ First return your data from `external` and then resume update handling using `wa
      * every replay. Prefer this over calling `Date.now()` directly.
      */
     async now() {
-        return await this.controls.action(() => Date.now(), "now");
+        const now = await this.controls.action(() => Date.now(), "now");
+        if (typeof now === "number") return now;
+        // backwards compatibility with previous implementation via `external`
+        return (now as { ret: number }).ret;
     }
     /**
      * Takes `Math.random()` once when reached, and returns the same value
      * during every replay. Prefer this over calling `Math.random()` directly.
      */
     async random() {
-        return await this.controls.action(() => Math.random(), "random");
+        const rand = await this.controls.action(() => Math.random(), "random");
+        if (typeof rand === "number") return rand;
+        // backwards compatibility with previous implementation via `external`
+        return (rand as { ret: number }).ret;
     }
     /**
      * Calls `console.log` only the first time it is reached, but not during


### PR DESCRIPTION
These changes bypass `external` for the util calls `conversation.now` etc. This also bypasses the concurrency check which is not needed for them. In addition, this compresses future data to use a simpler format, and it avoids a `structuredClone` call.

All of this enables concurrent calls to the util methods. As `conversation.now` is called inside `wait`, this is needed to re-enable concurrent wait calls.

Fixes #141.