### PR TITLE
fix: helpful error when `external` returns a non-cloneable value

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -926,7 +926,17 @@ First return your data from `external` and then resume update handling using `wa
         // Recover values after loading them
         const ret = await this.controls.action(action, "external");
         // Clone them to provide immutability
-        const cloned = structuredClone(ret);
+        let cloned: typeof ret;
+        try {
+            cloned = structuredClone(ret);
+        } catch (err) {
+            throw new Error(
+                "The value returned from `external` could not be cloned \
+for replay. Return a value that `structuredClone` can handle, or pass \
+`beforeStore` and `afterLoad` to serialize it yourself.",
+                { cause: err },
+            );
+        }
         if (cloned.ok) {
             return await afterLoad(cloned.ret);
         } else {

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -934,6 +934,7 @@ First return your data from `external` and then resume update handling using `wa
                 "The value returned from `external` could not be cloned \
 for replay. Return a value that `structuredClone` can handle, or pass \
 `beforeStore` and `afterLoad` to serialize it yourself.",
+                // @ts-ignore not available on old Node versions
                 { cause: err },
             );
         }

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -340,6 +340,24 @@ describe("Conversation", () => {
         assertEquals(i, 1);
         assertEquals(j, 0);
     });
+    it("should throw a helpful error when `external` returns a non-cloneable value", async () => {
+        const ctx = mkctx();
+        let caught: unknown;
+        async function convo(conversation: Convo) {
+            try {
+                await conversation.external(() => () => 0);
+            } catch (e) {
+                caught = e;
+            }
+            await conversation.wait();
+        }
+        const first = await enterConversation(convo, ctx);
+        assertEquals(first.status, "handled");
+        assertInstanceOf(caught, Error);
+        assertStringIncludes(caught.message, "could not be cloned");
+        assertStringIncludes(caught.message, "beforeStore");
+        assert(caught.cause instanceof Error);
+    });
     it("should support external with custom error formats", async () => {
         const ctx = mkctx();
         let i = 0;


### PR DESCRIPTION
## Summary

Closes #140.

`conversation.external(...)` clones its result with `structuredClone` so the value is immutable across replays. When the task returns a non-cloneable value (for example, a function), the native `DataCloneError` that falls out doesn't mention `external`, the conversation, or what to do about it — the reporter on #140 hit exactly this.

Wrap the `structuredClone(ret)` call in `src/conversation.ts` so that failures throw a new `Error` that:

- Names `external` as the site where cloning is required.
- Suggests `beforeStore` / `afterLoad` for custom serialization (already documented in the JSDoc above).
- Preserves the original `DataCloneError` on `.cause` for debugging.

## Changes

- `src/conversation.ts`: try/catch around `structuredClone(ret)`, rethrow with a helpful message and `cause`.
- `test/conversation.test.ts`: new case exercising `conversation.external(() => () => 0)` and asserting the new message and `cause`.

## Test plan

- [x] `deno task test --no-check` — 11 suites / 117 steps pass (the repo has pre-existing `RequestInit.body` type errors in `test/conversation.test.ts:390,525` that reproduce on `main` without this change).
- [x] `deno fmt --check`
- [x] `deno lint`