### PR TITLE
fix: mention Bot API calls in `external` wait-rejection error

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -253,7 +253,10 @@ export class Conversation<
         if (this.insideExternal) {
             throw new Error(
                 "Cannot wait for updates from inside `external`, or concurrently to it! \
-First return your data from `external` and then resume update handling using `wait` calls.",
+This also applies to Bot API calls (such as `ctx.api.getFile`, `ctx.reply`, \
+or chat actions) because they rely on `wait` internally, so perform \
+them outside of `external` instead. First return your data from `external` and \
+then resume update handling using `wait` calls.",
             );
         }
         const makeWait = async () => {


### PR DESCRIPTION
Closes #148.

The existing error tells the caller to return from \`external\` before \`wait\`ing, but the most common way users hit it is by making a Bot API call inside \`external\` — \`ctx.api.getFile\`, \`ctx.reply\`, chat actions, etc. Those funnel through \`wait\` internally, so the symptom is an obscure \`wait\` error from code that never called \`wait\` directly. The reporter on #148 and the maintainer both confirmed this is the root cause.

Extend the message to call out Bot API calls explicitly, so the fix is obvious without a reader needing to know \`wait\` is what powers API calls under the hood.

## Test plan

- [x] \`deno task test --no-check\` — 11/11 suites pass (pre-existing \`RequestInit.body\` type-check issue on \`main\` is unrelated).
- [x] \`deno fmt --check\`
- [x] \`deno lint\`