### PR TITLE
fix: clarify external error messages

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -253,6 +253,7 @@ export class Conversation<
         if (this.insideExternal) {
             throw new Error(
                 "Cannot wait for updates from inside `external`, or concurrently to it! \
+Bot API calls (e.g. ctx.api.*, ctx.reply) must not be made inside `external`. \
 First return your data from `external` and then resume update handling using `wait` calls.",
             );
         }

--- a/src/state.ts
+++ b/src/state.ts
@@ -211,7 +211,11 @@ export function cursor(state: ReplayState): ReplayCursor {
             // replay existing data (do nothing)
             const expected = state.send[send].payload;
             if (expected !== payload) {
-                throw new Error(`Bad replay, expected op '${expected}'`);
+                throw new Error(
+                    `Bad replay, expected op '${expected}' but got '${payload}'. \
+This usually means a Bot API call (e.g. ctx.api.*, ctx.reply) was made inside \
+\`conversation.external()\` or the conversation was otherwise used incorrectly.`,
+                );
             }
         } else { // send === state.send.length
             // log new data


### PR DESCRIPTION
Improve two error messages to help users identify the root cause faster:

### Changes

**src/conversation.ts** - `wait()` error message now explicitly mentions that Bot API calls must not be made inside `external()`:
> "Cannot wait for updates from inside `external`, or concurrently to it! Bot API calls (e.g. ctx.api.*, ctx.reply) must not be made inside `external`. First return your data from `external` and then resume update handling using `wait` calls."

**src/state.ts** - `Bad replay` error now shows both the expected and actual operation, plus a hint about the common cause:
> "Bad replay, expected op '...' but got '...'. This usually means a Bot API call was made inside \`conversation.external()\` or the conversation was otherwise used incorrectly."

Closes #148