### PR TITLE
fix: point lib.deno.dev imports at temporary mirror

### DIFF
--- a/src/deps.deno.ts
+++ b/src/deps.deno.ts
@@ -14,7 +14,7 @@ export {
     type Middleware,
     type MiddlewareFn,
     type ReactionContext,
-} from "https://lib.deno.dev/x/grammy@v1/mod.ts";
+} from "https://libdenodev.knightniwrem.deno.net/x/grammy@v1/mod.ts";
 export type {
     Animation,
     ApiError,
@@ -45,4 +45,4 @@ export type {
     Video,
     VideoNote,
     Voice,
-} from "https://lib.deno.dev/x/grammy@v1/types.ts";
+} from "https://libdenodev.knightniwrem.deno.net/x/grammy@v1/types.ts";


### PR DESCRIPTION
     lib.deno.dev is down since Classic Deno Deploy was sunset. As a
     temporary workaround, redirect imports to the community mirror at
     libdenodev.knightniwrem.deno.net.

     Mirror source: https://github.com/KnightNiwrem/lib.deno.dev/tree/main