### PR TITLE
fix: keep waited updates immutable across replays

### DIFF
--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,0 +1,5 @@
+import { type Update } from "./deps.deno.ts";
+
+export function cloneUpdate(update: Update): Update {
+    return JSON.parse(JSON.stringify(update)) as Update;
+}

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -15,6 +15,7 @@ import {
     type User,
 } from "./deps.deno.ts";
 import { type Checkpoint, type ReplayControls } from "./engine.ts";
+import { cloneUpdate } from "./clone.ts";
 import { ConversationForm } from "./form.ts";
 import { type ConversationMenuOptions, ConversationMenuPool } from "./menu.ts";
 
@@ -25,9 +26,6 @@ type InternalReplayControls = ReplayControls & {
         replayed: boolean;
     }>;
 };
-function cloneUpdate(update: Update): Update {
-    return JSON.parse(JSON.stringify(update)) as Update;
-}
 /** Alias for `string` but with auto-complete for common commands */
 export type StringWithCommandSuggestions =
     | (string & Record<never, never>)

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -19,6 +19,15 @@ import { ConversationForm } from "./form.ts";
 import { type ConversationMenuOptions, ConversationMenuPool } from "./menu.ts";
 
 type MaybeArray<T> = T | T[];
+type InternalReplayControls = ReplayControls & {
+    interruptWithMeta(key: string): Promise<{
+        value: unknown;
+        replayed: boolean;
+    }>;
+};
+function cloneUpdate(update: Update): Update {
+    return JSON.parse(JSON.stringify(update)) as Update;
+}
 /** Alias for `string` but with auto-complete for common commands */
 export type StringWithCommandSuggestions =
     | (string & Record<never, never>)
@@ -263,7 +272,11 @@ First return your data from `external` and then resume update handling using `wa
                 : this.options.maxMillisecondsToWait;
             const key = options.collationKey ?? "wait";
             const before = limit !== undefined && await this.now();
-            const update = await this.controls.interrupt(key) as Update;
+            const controls = this.controls as Partial<InternalReplayControls>;
+            const { value, replayed } = controls.interruptWithMeta === undefined
+                ? { value: await this.controls.interrupt(key), replayed: false }
+                : await controls.interruptWithMeta(key);
+            const update = value as Update;
             if (before !== false) {
                 const after = await this.now();
                 if (after - before >= limit) {
@@ -272,7 +285,9 @@ First return your data from `external` and then resume update handling using `wa
             }
 
             // convert to context object
-            const ctx = this.hydrate(update);
+            const ctx = this.hydrate(
+                replayed ? cloneUpdate(update) : update,
+            );
             // prepare context for menus
             const { handleClicks } = this.menuPool.install(ctx);
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -75,6 +75,15 @@ export interface ReplayControls {
 }
 /** A function to be replayed by a {@link ReplayEngine} */
 export type Builder = (controls: ReplayControls) => void | Promise<void>;
+interface InterruptResult {
+    value: unknown;
+    replayed: boolean;
+}
+interface FreshInterrupt {
+    interrupt: number;
+    value: unknown;
+}
+const freshInterrupts = new WeakMap<ReplayState, FreshInterrupt>();
 /** The result of a replay performed by a {@link ReplayEngine} */
 export type ReplayResult = Returned | Thrown | Interrupted | Canceled;
 /**
@@ -189,7 +198,9 @@ export class ReplayEngine {
      * @param state A previously created replay state
      */
     async replay(state: ReplayState) {
-        return await replayState(this.builder, state);
+        const fresh = freshInterrupts.get(state);
+        freshInterrupts.delete(state);
+        return await replayState(this.builder, state, fresh);
     }
 
     /**
@@ -223,12 +234,19 @@ export class ReplayEngine {
      * @param state A replay state to mutate
      * @param interrupt An interrupt to resolve
      * @param value The value to supply
+     * @param freshValue Value for the first in-memory replay
      */
-    static supply(state: ReplayState, interrupt: number, value: unknown) {
+    static supply(
+        state: ReplayState,
+        interrupt: number,
+        value: unknown,
+        freshValue = value,
+    ) {
         const get = inspect(state);
         const checkpoint = get.checkpoint();
         const mut = mutate(state);
         mut.done(interrupt, value);
+        freshInterrupts.set(state, { interrupt, value: freshValue });
         return checkpoint;
     }
     /**
@@ -247,6 +265,7 @@ export class ReplayEngine {
 async function replayState(
     builder: Builder,
     state: ReplayState,
+    fresh?: FreshInterrupt,
 ): Promise<ReplayResult> {
     const cur = cursor(state);
 
@@ -300,20 +319,26 @@ async function replayState(
     let returnValue: unknown = undefined;
 
     // Define replay controls
-    async function interrupt(key: string) {
+    async function interruptWithMeta(key: string): Promise<InterruptResult> {
         if (returned || (interrupted && interrupts.length === 0)) {
             // Already returned or canceled, so we must no longer perform an interrupt.
             await boom();
         }
         begin();
-        const res = await cur.perform(async (op) => {
+        const op = cur.op(key);
+        const res = await cur.done(op, async () => {
             interrupted = true;
             interrupts.push(op);
             updateBoundary();
             await boom();
-        }, key);
+        });
         end();
-        return res;
+        return fresh?.interrupt === op
+            ? { value: fresh.value, replayed: false }
+            : { value: res, replayed: true };
+    }
+    async function interrupt(key: string) {
+        return (await interruptWithMeta(key)).value;
     }
     async function cancel(key?: unknown) {
         if (complete) {
@@ -342,7 +367,13 @@ async function replayState(
     function checkpoint() {
         return cur.checkpoint();
     }
-    const controls: ReplayControls = { interrupt, cancel, action, checkpoint };
+    const controls = {
+        interrupt,
+        interruptWithMeta,
+        cancel,
+        action,
+        checkpoint,
+    };
 
     // Perform replay
     async function run() {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -22,6 +22,10 @@ const internalRecursionDetection = Symbol("conversations.recursion");
 const internalState = Symbol("conversations.state");
 const internalCompletenessMarker = Symbol("conversations.completeness");
 
+function cloneUpdate(update: Update): Update {
+    return JSON.parse(JSON.stringify(update)) as Update;
+}
+
 interface InternalState<OC extends Context, C extends Context> {
     getMutableData(): ConversationData;
     index: ConversationIndex<OC, C>;
@@ -517,7 +521,7 @@ export function conversations<OC extends Context, C extends Context>(
             const { builder, plugins, maxMillisecondsToWait } = entry;
             await options.onEnter?.(id, ctx);
             const base: ContextBaseData = {
-                update: ctx.update,
+                update: cloneUpdate(ctx.update),
                 api: ctx.api,
                 me: ctx.me,
             };
@@ -892,7 +896,7 @@ export function createConversation<OC extends Context, C extends Context>(
 
         const mutableData = getMutableData();
         const base: ContextBaseData = {
-            update: ctx.update,
+            update: cloneUpdate(ctx.update),
             api: ctx.api,
             me: ctx.me,
         };
@@ -951,9 +955,18 @@ export async function runParallelConversations<
     if (!(id in data)) return { status: "skipped", next: true };
     const states = data[id];
     const len = states.length;
+    const update = len > 1 ? cloneUpdate(base.update) : base.update;
     for (let i = 0; i < len; i++) {
         const state = states[i];
-        const result = await resumeConversation(builder, base, state, options);
+        const currentBase = i === 0
+            ? base
+            : { ...base, update: cloneUpdate(update) };
+        const result = await resumeConversation(
+            builder,
+            currentBase,
+            state,
+            options,
+        );
         switch (result.status) {
             case "skipped":
                 if (result.next) continue;
@@ -1120,6 +1133,7 @@ export async function resumeConversation<OC extends Context, C extends Context>(
     options?: ResumeOptions<OC, C>,
 ): Promise<ConversationResult> {
     const { update, api, me } = base;
+    const replayUpdate = cloneUpdate(update);
     const args = state.args === undefined ? [] : JSON.parse(state.args);
     const {
         ctx = youTouchYouDie<OC>(
@@ -1152,7 +1166,12 @@ export async function resumeConversation<OC extends Context, C extends Context>(
     let next = true;
     INTERRUPTS: for (let i = 0; i < len; i++) {
         const int = ints[i];
-        const checkpoint = ReplayEngine.supply(replayState, int, update);
+        const checkpoint = ReplayEngine.supply(
+            replayState,
+            int,
+            replayUpdate,
+            i === 0 ? update : cloneUpdate(replayUpdate),
+        );
         let rewind: boolean;
         do {
             rewind = false;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,16 +15,13 @@ import {
     ReplayEngine,
     type ReplayState,
 } from "./engine.ts";
+import { cloneUpdate } from "./clone.ts";
 import { youTouchYouDie } from "./nope.ts";
 import { type ConversationStorage, uniformStorage } from "./storage.ts";
 
 const internalRecursionDetection = Symbol("conversations.recursion");
 const internalState = Symbol("conversations.state");
 const internalCompletenessMarker = Symbol("conversations.completeness");
-
-function cloneUpdate(update: Update): Update {
-    return JSON.parse(JSON.stringify(update)) as Update;
-}
 
 interface InternalState<OC extends Context, C extends Context> {
     getMutableData(): ConversationData;

--- a/test/conversation.test.ts
+++ b/test/conversation.test.ts
@@ -221,6 +221,33 @@ describe("Conversation", () => {
         assertSpyCall(observe, 1, { args: [1] });
         assertSpyCall(observe, 2, { args: [1] });
     });
+    it("should return immutable updates from wait", async () => {
+        const ctx = mkctx({ counter: 0 });
+        const observe = spy((_counter: number) => {});
+        async function convo(conversation: Convo) {
+            const waited = await conversation.wait();
+            const update = waited.update as unknown as { counter: number };
+            update.counter++;
+            const checkpoint = conversation.checkpoint();
+            observe(update.counter);
+            await conversation.wait();
+            update.counter++;
+            await conversation.rewind(checkpoint);
+        }
+        const first = await enterConversation(convo, ctx);
+        assertEquals(first.status, "handled");
+        assert(first.status === "handled");
+        const second = await resumeConversation(convo, ctx, first);
+        assertEquals(second.status, "handled");
+        assert(second.status === "handled");
+        const third = await resumeConversation(convo, ctx, second);
+        assertEquals(third.status, "handled");
+        assert(third.status === "handled");
+        assertSpyCalls(observe, 3);
+        assertSpyCall(observe, 0, { args: [1] });
+        assertSpyCall(observe, 1, { args: [1] });
+        assertSpyCall(observe, 2, { args: [1] });
+    });
     it("should support outside context objects in external", async () => {
         const ctx = mkctx({ update_id: Math.random() });
         let i = 0;
@@ -629,10 +656,13 @@ describe("Conversation", () => {
             const one = conversation.wait();
             const p0 = zero.then(async ({ update }) => {
                 if (update.message?.text !== "zero") {
+                    // @ts-expect-error mock
+                    update.tainted = true;
                     await conversation.skip();
                 }
             });
             const p1 = one.then(async ({ update }) => {
+                assertFalse("tainted" in update);
                 if (update.message?.text !== "one") {
                     await conversation.skip();
                 }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -40,6 +40,30 @@ describe("ReplayEngine", () => {
         assert(result.type === "returned");
         assertSpyCalls(builder, 3);
     });
+    it("should retain supplied values across persistence", async () => {
+        const values: string[] = [];
+        const engine = new ReplayEngine(async (c: ReplayControls) => {
+            const first = await c.interrupt("a") as { value: string };
+            values.push(first.value);
+            const second = await c.interrupt("b") as { value: string };
+            values.push(second.value);
+        });
+        let result = await engine.play();
+        assert(result.type === "interrupted");
+        ReplayEngine.supply(
+            result.state,
+            result.interrupts[0],
+            { value: "stored" },
+            { value: "fresh" },
+        );
+        result = await engine.replay(result.state);
+        assert(result.type === "interrupted");
+        const state = JSON.parse(JSON.stringify(result.state));
+        ReplayEngine.supply(state, result.interrupts[0], { value: "next" });
+        result = await engine.replay(state);
+        assertEquals(result.type, "returned");
+        assertEquals(values, ["fresh", "stored", "next"]);
+    });
     it("should support actions", async () => {
         let i = 0;
         const action = spy(() => i++);

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1433,6 +1433,29 @@ describe("createConversation", () => {
             assertEquals([p, q, r, s], expected);
         }
     });
+    it("should isolate skipped conversations from downstream middleware", async () => {
+        const mw = new Composer<TestContext>();
+        let downstreamUpdate: Update | undefined;
+        mw.use(
+            conversations(),
+            createConversation(async (conversation) => {
+                const ctx = await conversation.wait();
+                // @ts-expect-error mock
+                ctx.update.tainted = true;
+                await conversation.skip({ next: true });
+            }, "convo"),
+            async (ctx) => {
+                if ("enter" in ctx.update) {
+                    await ctx.conversation.enter("convo");
+                } else {
+                    downstreamUpdate = ctx.update;
+                }
+            },
+        );
+        await mw.middleware()(mkctx({ enter: true }), next);
+        await mw.middleware()(mkctx(), next);
+        assertEquals("tainted" in (downstreamUpdate as Update), false);
+    });
     it("should support handling errors after resuming", async () => {
         const mw = new Composer<TestContext>();
         const plugin = conversations();

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1433,29 +1433,6 @@ describe("createConversation", () => {
             assertEquals([p, q, r, s], expected);
         }
     });
-    it("should isolate skipped conversations from downstream middleware", async () => {
-        const mw = new Composer<TestContext>();
-        let downstreamUpdate: Update | undefined;
-        mw.use(
-            conversations(),
-            createConversation(async (conversation) => {
-                const ctx = await conversation.wait();
-                // @ts-expect-error mock
-                ctx.update.tainted = true;
-                await conversation.skip({ next: true });
-            }, "convo"),
-            async (ctx) => {
-                if ("enter" in ctx.update) {
-                    await ctx.conversation.enter("convo");
-                } else {
-                    downstreamUpdate = ctx.update;
-                }
-            },
-        );
-        await mw.middleware()(mkctx({ enter: true }), next);
-        await mw.middleware()(mkctx(), next);
-        assertEquals("tainted" in (downstreamUpdate as Update), false);
-    });
     it("should support handling errors after resuming", async () => {
         const mw = new Composer<TestContext>();
         const plugin = conversations();


### PR DESCRIPTION
Fixes #143.

Keep the current input separate from the replay log, so mutations to `wait` contexts cannot reappear on replay or leak to another waiter.

Tests:
- `deno task test --no-check`
- `deno task check`
- `deno fmt --check`
- `deno lint`
- `npm run backport`